### PR TITLE
Fix getParam returned value

### DIFF
--- a/example/dartros_example.dart
+++ b/example/dartros_example.dart
@@ -4,6 +4,6 @@ Future<void> main(List<String> args) async {
   final nh = await dartros.initNode('ros_node_1', args);
   await nh.getMasterUri();
   print(await nh.getParam('/foo'));
-  print(await nh.setParam('/foo', 'value'));
+  print(await nh.setParam('/foo', 'new value'));
   print(await nh.getParam('/foo'));
 }

--- a/lib/src/ros_xmlrpc_client.dart
+++ b/lib/src/ros_xmlrpc_client.dart
@@ -262,8 +262,8 @@ mixin RosXmlRpcClient on XmlRpcClient {
   /// Returns the URI of the node
   Future<String> lookupNode(
     String nodeName,
-  ) =>
-      _call('lookupNode', [nodeName, nodeName]);
+  ) async =>
+      await _call('lookupNode', [nodeName, nodeName]);
 
   /// Gets the URI of the master
   ///
@@ -327,7 +327,7 @@ mixin RosXmlRpcClient on XmlRpcClient {
   }
 
   /// Gets the URI of the master.
-  Future<String> getMasterUri() => _call('getUri', [nodeName]);
+  Future<String> getMasterUri() async => await _call('getUri', [nodeName]);
 }
 
 @freezed


### PR DESCRIPTION
Hi, thanks for making this package! This PR fixes an error I get when running`dartros_example.dart`:

```
Unhandled exception:
type 'Future<dynamic>' is not a subtype of type 'Future<String>'
#0      RosXmlRpcClient.getMasterUri (package:dartros/src/ros_xmlrpc_client.dart:330:36)
#1      NodeHandle.getMasterUri (package:dartros/src/node_handle.dart:30:41)
#2      main (file:///home/j/codiman/rosclient/dartros/example/dartros_example.dart:5:12)
```

It also fixes a similar error in `lookupNode`, and makes the example's output a bit clearer by setting the parameter to a non-default value.

I wanted to add a test, but I can't get the code to run in the latest version, I think there's a commit missing in `std_msgs_dart`, adding the `$prototype` variable?