### PR TITLE
Lint fixes

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -356,7 +356,7 @@ linter:
     # recommendation: optional
     # reason: There are several outstanding bugs with this lint that cause a good deal of noise
     # 0 issues
-    - invariant_booleans
+    # - invariant_booleans
 
     # Invocation of Iterable<E>.contains with references of unrelated types.
     # http://dart-lang.github.io/linter/lints/iterable_contains_unrelated_type.html

--- a/example/pub_image.dart
+++ b/example/pub_image.dart
@@ -15,7 +15,7 @@ Future<void> main(List<String> args) async {
       data: List.generate(600 * 1024 * 4, (_) => 255));
   final pub = node.advertise<Image>('/robot/head_display', sensor_msgs.Image);
   await Future.delayed(2.seconds);
-  while (true) {
+  for (;;) {
     pub.publish(img_msg, 1);
     await Future.delayed(2.seconds);
   }

--- a/lib/src/impl/publisher_impl.dart
+++ b/lib/src/impl/publisher_impl.dart
@@ -11,7 +11,7 @@ import '../node.dart';
 import '../utils/client_states.dart';
 import '../utils/log/logger.dart';
 
-var msgCount = 0;
+int msgCount = 0;
 
 class PublisherImpl<T extends RosMessage> {
   PublisherImpl(
@@ -155,9 +155,7 @@ class PublisherImpl<T extends RosMessage> {
     udpSubClients[client.toString()] = options;
   }
 
-  bool isUdpSubscriber(String client) {
-    return udpSubClients.keys.contains(client);
-  }
+  bool isUdpSubscriber(String client) => udpSubClients.keys.contains(client);
 
   Future<void> sendMsgToUdpClients(Uint8List serialized) async {
     for (final client in udpSubClients.values) {

--- a/lib/src/node.dart
+++ b/lib/src/node.dart
@@ -247,7 +247,7 @@ class Node extends rpc_server.XmlRpcHandler
               (topic) => _subscribers[topic].connectionId == connId,
               orElse: () => null);
           if (topic != null) {
-            await _subscribers[topic].handleMessageChunk(header, reader);
+            _subscribers[topic].handleMessageChunk(header, reader);
           } else {
             log.dartros.info('Got connection header for unknown topic $topic');
           }

--- a/lib/src/service_server.dart
+++ b/lib/src/service_server.dart
@@ -83,7 +83,7 @@ class ServiceServer<C extends RosMessage<C>, R extends RosMessage<R>,
           return;
         }
       }
-    } catch (e) {
+    } on Exception catch (e) {
       _clients.remove(name);
       log.dartros.debug('Service client $name disconnected with error: $e!');
     }
@@ -98,7 +98,7 @@ class ServiceServer<C extends RosMessage<C>, R extends RosMessage<R>,
         return;
       }
       _state = State.REGISTERED;
-    } catch (e) {
+    } on Exception catch (e) {
       log.dartros.error('Error while registering service $service: error: $e');
     }
   }


### PR DESCRIPTION
This fixes various lint complaints, and a also disables a buggy lint that was falsely suggesting to remove a check for `isShutdown` in `handleClientConnection`.