### PR TITLE
suscriber: copy keys for shutdown iteration

### DIFF
--- a/lib/src/impl/subscriber_impl.dart
+++ b/lib/src/impl/subscriber_impl.dart
@@ -71,14 +71,10 @@ class SubscriberImpl<T extends RosMessage<T>> {
   Future<void> shutdown() async {
     _state = State.SHUTDOWN;
     //TODO: log some things
-    for (final client in pubClients.keys) {
+    // Iterate on copy of keys so we can remove items during the iteration
+    for (final client in [...pubClients.keys, ...pendingClients.keys]) {
       await _disconnectClient(client);
     }
-    pubClients.clear();
-    for (final client in pendingClients.keys) {
-      await _disconnectClient(client);
-    }
-    pendingClients.clear();
     // TODO: spinner thing
   }
 


### PR DESCRIPTION
This fixes an exception thrown when doing Ctrl-C on example/sub.dart

(The change removes the explicit clearing of client lists but it's not necessary since _disconnectClient does it anyway.)