### PR TITLE
Fix simple action client/server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,8 @@ doc/api/
 
 # Directory created by dartdoc
 .vscode
+
+# Temporary editor files
+*~
+*.swp
+*.swo

--- a/lib/dartros.dart
+++ b/lib/dartros.dart
@@ -3,6 +3,8 @@
 /// More dartdocs go here.
 library dartros;
 
+export 'src/actions/simple_action_client.dart';
+export 'src/actions/simple_action_server.dart';
 export 'src/actionlib_client.dart';
 export 'src/actionlib_server.dart';
 export 'src/dartros.dart';

--- a/lib/src/actions/action_server.dart
+++ b/lib/src/actions/action_server.dart
@@ -26,7 +26,7 @@ class ActionServer<
   Timer _statusFreqTimer;
   void Function(GoalHandle) goalHandle;
   void Function(GoalHandle) cancelHandle;
-  final Map<String, int> _pubSeqs = {'result': 0, 'Feedback': 0, 'status': 0};
+  final Map<String, int> _pubSeqs = {'result': 0, 'feedback': 0, 'status': 0};
 
   void start() {
     _started = true;

--- a/lib/src/actions/simple_action_client.dart
+++ b/lib/src/actions/simple_action_client.dart
@@ -24,7 +24,7 @@ class SimpleActionClient<
   void Function() _activeCallback;
   void Function(SimpleGoalState, R) _doneCallback;
 
-  Future<void> waitForServer([int timeoutMs = 0]) =>
+  Future<bool> waitForServer([int timeoutMs = 0]) =>
       waitForActionServerToStart(timeoutMs);
 
   void sendSimpleGoal(
@@ -98,7 +98,7 @@ class SimpleActionClient<
     const WAIT_TIME_MS = 10;
 
     final now = RosTime.now();
-    if (timeoutTime && timeoutTime < now) {
+    if (timeoutTime < now) {
       return _state == SimpleGoalState.DONE;
     } else if (_state == SimpleGoalState.DONE) {
       return true;
@@ -284,5 +284,6 @@ class SimpleActionClient<
   void _setSimpleState(SimpleGoalState newState) {
     log.dartros
         .debug('Transitioning SimpleState from [$_state] to [$newState]');
+    _state = newState;
   }
 }

--- a/lib/src/utils/msg_utils.dart
+++ b/lib/src/utils/msg_utils.dart
@@ -67,7 +67,8 @@ extension LenInBytes on String {
 extension ByteDataReaderRosDeserializers on ByteDataReader {
   String readString() {
     final len = readUint32();
-    return utf8.decode(read(len));
+    // ByteDataReader.read(0) throws if there is no byte to read
+    return len > 0 ? utf8.decode(read(len)) : '';
   }
 
   RosTime readTime() {


### PR DESCRIPTION
These are a few fixes to make SimpleActionClient and SimpleActionServer work.

Remarks:

* `simple_action_client.dart` and `simple_action_server.dart` are now exported. I didn't change the export status of `actionlib_{client,server}.dart` (exported) and `action_{client,server}.dart' (unexported).
* I'm not sure of the best place for test cases, since we need quite a few messages. For now I'll make a PR with test code in https://github.com/TimWhiting/test_dart_ros .
* I didn't find a way to properly shut down the nodes: they still appear in the output of `rosnode list` (unlike Python nodes which disappear after shutdown).
* I've tested this with ROS Noetic.

Closes #12