### PR TITLE
Give hostname priority over IP

### DIFF
--- a/lib/src/utils/network_utils.dart
+++ b/lib/src/utils/network_utils.dart
@@ -19,7 +19,7 @@ class _NetworkUtils {
     _ros_ip = Platform.environment['ROS_IP'];
     _ros_hostname = Platform.environment['ROS_HOSTNAME'];
     _host =
-        _ip ?? _hostname ?? _ros_ip ?? _ros_hostname ?? Platform.localHostname;
+        _hostname ?? _ip ?? _ros_hostname ?? _ros_ip ?? Platform.localHostname;
   }
 
   String getAddressFromUri(String uriString) => Uri.parse(uriString).host;


### PR DESCRIPTION
A fairly minor change... I noticed that according to http://wiki.ros.org/ROS/EnvironmentVariables#ROS_IP.2FROS_HOSTNAME the hostname is supposed to take precedence over the IP if both are defined.